### PR TITLE
JSON for Faraday moved to faraday_middleware

### DIFF
--- a/lib/ghee/connection.rb
+++ b/lib/ghee/connection.rb
@@ -20,7 +20,7 @@ class Ghee
       basic_auth = hash[:basic_auth] if hash.has_key?:basic_auth
 
       super('https://api.github.com') do |builder|
-        builder.use     Faraday::Request::JSON
+        builder.use     FaradayMiddleware::EncodeJson
         builder.use     FaradayMiddleware::ParseJson
         builder.adapter Faraday.default_adapter
       end


### PR DESCRIPTION
I was having issues getting Ghee to authenticate with this error:

```
>> require 'ghee'
Faraday: you may want to install system_timer for reliable timeouts
=> true
>> user_name, password, scopes = "willrax", "secret", ["user","repos"]
=> ["willrax", "secret", ["user", "repos"]]
>> token = Ghee.create_token(user_name, password, scopes)
NameError: uninitialized constant Faraday::Request::JSON
```

I traced this back to connection.rb which i then traced to faraday which then went to faraday_middleware. It seems that this:

```
Faraday::Request::JSON
```

was stripped from faraday and placed in to faraday_middleware. 

technoweenie/faraday@db554b29260ff469e40e530af498b38433ede8ab

This small change seems to fix it. I was getting some errors complaining that the json gem wasn't loaded but haven't been able to recreate. This would most likely be an issue with faraday_middleware anyway.
