### PR TITLE
Update the documentation for creating an OAuth access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Instantiate the client with auth token:
 
 Create an OAuth access token:
 
-    user_name, password, scopes = "rauhryan", "secret", ["user","repos"]
+    user_name, password, scopes = "rauhryan", "secret", ["user","repo"]
     token = Ghee.create_token(user_name, password, scopes)
 
 ## Gists


### PR DESCRIPTION
According to the Github v3 API, the correct scope is the singular version of "repo" instead of "repos".

[More Information](http://developer.github.com/v3/oauth/#scopes)
