### PR TITLE
Modified Urls passed to the connection to address url building rules with Github Enterprise

### DIFF
--- a/lib/ghee/api/authorizations.rb
+++ b/lib/ghee/api/authorizations.rb
@@ -6,7 +6,7 @@ class Ghee
       end
 
       def authorizations(number=nil)
-        prefix = number ? "/authorizations/#{number}" : "/authorizations"
+        prefix = number ? "./authorizations/#{number}" : "./authorizations"
         Ghee::API::Authorizations::Proxy.new(connection, prefix)
       end
     end

--- a/lib/ghee/api/events.rb
+++ b/lib/ghee/api/events.rb
@@ -17,7 +17,7 @@ class Ghee
       # Returns json
       #
       def events(params={})
-        return Proxy.new(connection, "/events",params)
+        return Proxy.new(connection, "./events",params)
       end
       
     end

--- a/lib/ghee/api/gists.rb
+++ b/lib/ghee/api/gists.rb
@@ -76,7 +76,7 @@ class Ghee
       #
       def gists(id=nil, params={})
         params = id if id.is_a?Hash
-        path_prefix = (!id.is_a?(Hash) and id) ? "/gists/#{id}" : '/gists'
+        path_prefix = (!id.is_a?(Hash) and id) ? "./gists/#{id}" : './gists'
         Proxy.new(connection, path_prefix,params)
       end
     end

--- a/lib/ghee/api/orgs.rb
+++ b/lib/ghee/api/orgs.rb
@@ -61,7 +61,7 @@ class Ghee
         #
         def teams(number=nil,params={})
           params = number if number.is_a?Hash
-          prefix = (!number.is_a?(Hash) and number) ? "/teams/#{number}" : "#{path_prefix}/teams"
+          prefix = (!number.is_a?(Hash) and number) ? "./teams/#{number}" : "#{path_prefix}/teams"
           Ghee::API::Orgs::Teams::Proxy.new(connection, prefix, params)
         end
 
@@ -71,7 +71,7 @@ class Ghee
         #
         def repos(name=nil,params={})
           params = name if name.is_a?Hash
-          prefix = (!name.is_a?(Hash) and name) ? "/repos/#{self["login"]}/#{name}" : "#{path_prefix}/repos"
+          prefix = (!name.is_a?(Hash) and name) ? "./repos/#{self["login"]}/#{name}" : "#{path_prefix}/repos"
           Ghee::API::Repos::Proxy.new(connection,prefix,params)
         end
       end
@@ -94,7 +94,7 @@ class Ghee
       #
       def orgs(name=nil, params={})
         params = name if name.is_a?Hash
-        prefix = (!name.is_a?(Hash) and name) ? "/orgs/#{name}" : "user/orgs"
+        prefix = (!name.is_a?(Hash) and name) ? "./orgs/#{name}" : "user/orgs"
         Proxy.new(connection, prefix, params)
       end
     end

--- a/lib/ghee/api/repos.rb
+++ b/lib/ghee/api/repos.rb
@@ -25,7 +25,7 @@ class Ghee
       #
       def repos(login,name = nil)
         repo = name.nil? ? login : "#{login}/#{name}"
-        path_prefix = "/repos/#{repo}"
+        path_prefix = "./repos/#{repo}"
         proxy = Proxy.new(connection, path_prefix)
         proxy.repo_name = repo
         proxy

--- a/lib/ghee/api/search.rb
+++ b/lib/ghee/api/search.rb
@@ -10,7 +10,7 @@ class Ghee
       module Issues
         class Proxy < ::Ghee::ResourceProxy
           def search(term, state = "open")
-            url = "/legacy/issues/search/#{@repo.repo_name}/#{state}/#{term}"
+            url = "./legacy/issues/search/#{@repo.repo_name}/#{state}/#{term}"
             Ghee::API::Search::Issues::Proxy.new(connection, url)
           end
         end
@@ -27,7 +27,7 @@ class Ghee
       end
       class Proxy < ::Ghee::ResourceProxy
         def issues(repo, term, state = "open")
-            url = "/legacy/issues/search/#{repo}/#{state}/#{term}"
+            url = "./legacy/issues/search/#{repo}/#{state}/#{term}"
             Issues::Proxy.new(connection, url)
         end
       end

--- a/lib/ghee/api/users.rb
+++ b/lib/ghee/api/users.rb
@@ -30,7 +30,7 @@ class Ghee
         #
         def repos(name=nil, params={})
           params = name if name.is_a?Hash
-          prefix = name.is_a?(String) ? "/repos/#{self["login"]}/#{name}" : "#{path_prefix}/repos" 
+          prefix = name.is_a?(String) ? "./repos/#{self["login"]}/#{name}" : "#{path_prefix}/repos" 
           Ghee::API::Repos::Proxy.new(connection,prefix, params)
         end
 
@@ -43,7 +43,7 @@ class Ghee
         #
         def orgs(org=nil, params={})
           params = org if org.is_a?Hash
-          prefix = org.is_a?(String) ? "/orgs/#{org}" : "#{path_prefix}/orgs"
+          prefix = org.is_a?(String) ? "./orgs/#{org}" : "#{path_prefix}/orgs"
           Ghee::API::Orgs::Proxy.new(connection, prefix, params)
         end
 
@@ -55,7 +55,7 @@ class Ghee
       # Returns json
       #
       def user
-        Proxy.new(connection, '/user')
+        Proxy.new(connection, './user')
       end
 
       # Get a single user
@@ -65,7 +65,7 @@ class Ghee
       # Returns json
       #
       def users(user)
-        Proxy.new(connection, "/users/#{user}")
+        Proxy.new(connection, "./users/#{user}")
       end
     end
   end


### PR DESCRIPTION
currently does "http://example.github.com/api/v3/" + "/user"  =
"http://example.github.com/user".  Now builds properly using linux path
building rules "http://example.github.com/api/v3/" + "./user"  =
"http://example.github.com/api/v3/user"

<!---
@huboard:{"order":0.040231622755527496}
-->
