### PR TITLE
Change faraday gem version.

### DIFF
--- a/ghee.gemspec
+++ b/ghee.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'faraday', '~> 0.8'
+  s.add_dependency 'faraday', '< 0.9', '>= 0.8'
   s.add_dependency 'faraday_middleware', '~> 0.9'
   s.add_dependency 'hashie', '~> 1.2'
   s.add_dependency 'multi_json', '~> 1.3'


### PR DESCRIPTION
faraday_middleware needs faraday's version < 0.9, so we should
change the faraday's version, or `gem install` will fail.
