### PR TITLE
Fix invalid scope in `ghee install` cli.

### DIFF
--- a/bin/ghee
+++ b/bin/ghee
@@ -63,7 +63,7 @@ if options[:install]
   ghee = Ghee.basic_auth user, HL.get_password
 
   auth = ghee.authorizations.create(
-    :scopes => ["repo","user","gists"],
+    :scopes => ["repo","user","gist"],
     :note => "ghee api key",
     :note_url => "https://github.com/rauhryan/ghee"
   )


### PR DESCRIPTION
According to https://developer.github.com/v3/oauth/#scopes,
gists is not an valid scope, gist is.
