### PR TITLE
Implements and tests passing blocks for requests on `ResourceProxy.all`

### DIFF
--- a/lib/ghee/resource_proxy.rb
+++ b/lib/ghee/resource_proxy.rb
@@ -81,12 +81,13 @@ class Ghee
   #
   # Returns self
   #
-  def paginate(options)
+  def paginate(options, &block)
     @current_page = options.fetch(:page) {raise ArgumentError, ":page parameter required"}
     per_page = options.delete(:per_page) || 30
     response = connection.get do |req|
       req.url path_prefix, :per_page => per_page, :page => current_page
       req.params.merge! params
+      block.call(req)
     end
 
     if @subject.nil?
@@ -100,12 +101,12 @@ class Ghee
     return self      
   end
 
-  def all
+  def all(&block)
     return self if pagination && next_page.nil?
 
-    self.paginate :per_page => 100, :page => next_page || 1
+    self.paginate :per_page => 100, :page => next_page || 1, &block
 
-    self.all
+    self.all(&block)
   end
 
   def all_parallel

--- a/lib/ghee/version.rb
+++ b/lib/ghee/version.rb
@@ -1,4 +1,4 @@
 # encoding: UTF-8
 class Ghee
-  VERSION = "0.14.20"
+  VERSION = "0.14.21"
 end

--- a/spec/ghee/resource_proxy_spec.rb
+++ b/spec/ghee/resource_proxy_spec.rb
@@ -65,6 +65,29 @@ describe "Pagination" do
     end
   end
 
+  describe "#all with block" do
+    before(:each) do
+      @connection = mock('connection')
+      @request = OpenStruct.new()
+      @request.stub(:url)
+      @request.stub(:params).and_return(Hash.new)
+
+      @block = Proc.new {}
+      @connection.stub!(:get)
+        .and_yield(@request)
+        .and_return(IncrementPager.new 1)
+    end
+
+    subject do 
+      Ghee::ResourceProxy.new(@connection, '/foo')
+    end
+
+    it "Passes the request down to the block" do 
+      @block.should_receive(:call).with(@request)
+      subject.all(&@block)
+    end
+  end
+
 
   describe "past first page" do 
 


### PR DESCRIPTION
Allows request headers to be modified on `ResourceProxy.all`:

```ruby
gh.issues().all do |req|
  req.headers["Accept"] = "fancyheader"
end
```